### PR TITLE
ES6 就是 ES2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 说明
 
-本项目使用 es2017 编码方式开发，感谢 [labrador](https://segmentfault.com/a/1190000007109050) 。
+本项目使用 ES2015 编码方式开发，感谢 [labrador](https://segmentfault.com/a/1190000007109050) 。
 
  - dist 项目编译后代码，在IDE新建项目时必须选择该文件夹预览
  - src 项目源代码目录，在里面可使用 es2017 语法


### PR DESCRIPTION
看了下您 .babelrc  的配置，也没用 [babel-preset-es2017](https://www.npmjs.com/package/babel-preset-es2017)这个插件啊。

ES6 就是 ES2015，ES7 还没成为标准，所以没有 ES2016 这个说法。更没 ES2017 这个说法，嘿嘿。
